### PR TITLE
Disallow negative blood alcohol content

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var BALLMER_PEAK_BAC = 0.12;
 
 // Get BAC from weight (lbs), bender, time elapsed (hours) and # standard drinks
 function getBac(weight, genderConstant, time, numDrinks) {
-  return (numDrinks / BOOZE_CONST / weight / genderConstant) - (TIME_CONST * time);
+  return Math.max((numDrinks / BOOZE_CONST / weight / genderConstant) - (TIME_CONST * time), 0);
 }
 
 // Get # of standard drinks from weight (lbs), gender, time elapsed (hours), and BAC


### PR DESCRIPTION
The graphs of BAC glitched a bit in my browser and I noticed it was possible for the BAC to dive below zero, which is unlikely. I fixed it by disallowing negative BAC's.

If pull requests are welcome on this repository, I have a few more ideas that I could implement, one of which is an option for constantly maintaining the Ballmer Peak for a timespan.